### PR TITLE
Add React Router and menu example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,42 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## React Router 사용하기
+
+`react-router-dom`을 이용해 페이지를 라우팅하고 메뉴를 구성할 수 있습니다. 기본 절차는 아래와 같습니다.
+
+1. 패키지 설치
+
+   ```bash
+   npm install react-router-dom
+   ```
+
+2. `src/main.jsx`에서 `BrowserRouter`로 애플리케이션을 감쌉니다.
+3. `src/App.jsx`에서 메뉴와 라우트를 정의합니다.
+
+   ```jsx
+   import { Layout, Menu } from "antd";
+   import { Link, Route, Routes } from "react-router-dom";
+
+   <Layout>
+     <Header>
+       <Menu theme="dark" mode="horizontal">
+         <Menu.Item key="home">
+           <Link to="/">홈</Link>
+         </Menu.Item>
+         <Menu.Item key="about">
+           <Link to="/about">소개</Link>
+         </Menu.Item>
+       </Menu>
+     </Header>
+     <Content>
+       <Routes>
+         <Route path="/" element={<Home />} />
+         <Route path="/about" element={<About />} />
+       </Routes>
+     </Content>
+   </Layout>
+   ```
+
+위와 같이 설정하면 두 개의 메뉴(홈, 소개)를 가진 기본적인 라우터가 완성됩니다.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "antd": "^5.26.6",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,56 +1,27 @@
-import { Col, Layout, Row, Typography } from "antd";
-
+import { Layout, Menu } from "antd";
 import { Content, Footer, Header } from "antd/es/layout/layout";
+import { Link, Route, Routes } from "react-router-dom";
+import Home from "./pages/Home.jsx";
+import About from "./pages/About.jsx";
 
 function App() {
-  
   return (
-    <Layout style={{ minHeight: "100vh", minWidth: "100vw", maxWidth: "100vw"}}>
-      <Header style={{color:"#fff"}}>
-        헤더
+    <Layout style={{ minHeight: "100vh", minWidth: "100vw", maxWidth: "100vw" }}>
+      <Header style={{ padding: 0 }}>
+        <Menu theme="dark" mode="horizontal">
+          <Menu.Item key="home">
+            <Link to="/">홈</Link>
+          </Menu.Item>
+          <Menu.Item key="about">
+            <Link to="/about">소개</Link>
+          </Menu.Item>
+        </Menu>
       </Header>
-      <Content>
-        <Row>
-          <Col span={24}>
-            <Typography.Title type="secondary" level={2}>
-              1줄 1칸
-            </Typography.Title>
-          </Col>
-        </Row>
-        <Row>
-          <Col span={12}>
-            <Typography.Title type="secondary" level={2}>
-              2줄 1칸
-            </Typography.Title>
-          </Col>
-          <Col span={12}>
-            <Typography.Title type="secondary" level={2}>
-              2줄 2칸
-            </Typography.Title>
-          </Col>
-        </Row>
-        <Row>
-          <Col span={6}>
-            <Typography.Title type="secondary" level={2}>
-              3줄 1칸
-            </Typography.Title>
-          </Col>
-          <Col span={6}>
-            <Typography.Title type="secondary" level={2}>
-              3줄 2칸
-            </Typography.Title>
-          </Col>
-          <Col span={6}>
-            <Typography.Title type="secondary" level={2}>
-              3줄 3칸
-            </Typography.Title>
-          </Col>
-          <Col span={6}>
-            <Typography.Title type="secondary" level={2}>
-              3줄 4칸
-            </Typography.Title>
-          </Col>
-        </Row>
+      <Content style={{ padding: "1rem" }}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+        </Routes>
       </Content>
       <Footer>푸터</Footer>
     </Layout>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,11 @@
+import { Typography } from "antd";
+
+function About() {
+  return (
+    <Typography.Title type="secondary" level={2}>
+      About Page
+    </Typography.Title>
+  );
+}
+
+export default About;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,51 @@
+import { Col, Row, Typography } from "antd";
+
+function Home() {
+  return (
+    <>
+      <Row>
+        <Col span={24}>
+          <Typography.Title type="secondary" level={2}>
+            1줄 1칸
+          </Typography.Title>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={12}>
+          <Typography.Title type="secondary" level={2}>
+            2줄 1칸
+          </Typography.Title>
+        </Col>
+        <Col span={12}>
+          <Typography.Title type="secondary" level={2}>
+            2줄 2칸
+          </Typography.Title>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={6}>
+          <Typography.Title type="secondary" level={2}>
+            3줄 1칸
+          </Typography.Title>
+        </Col>
+        <Col span={6}>
+          <Typography.Title type="secondary" level={2}>
+            3줄 2칸
+          </Typography.Title>
+        </Col>
+        <Col span={6}>
+          <Typography.Title type="secondary" level={2}>
+            3줄 3칸
+          </Typography.Title>
+        </Col>
+        <Col span={6}>
+          <Typography.Title type="secondary" level={2}>
+            3줄 4칸
+          </Typography.Title>
+        </Col>
+      </Row>
+    </>
+  );
+}
+
+export default Home;


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- create `Home` and `About` pages
- implement router with navigation menu
- describe how to add the router and menu in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ae3b280ac832f9ae1e3d3d97c5606