### PR TITLE
Enable manual GitHub Action trigger

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -6,6 +6,7 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger to npm publish workflow for manual runs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893fb92c390832f94dfd35cef123a33