### PR TITLE
ci: use npm install with caching

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - run: npm install
       - run: npm test
 
   publish-gpr:
@@ -31,7 +33,9 @@ jobs:
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
-      - run: npm ci
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - run: npm install
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- use `npm install` in CI workflows instead of `npm ci`
- cache npm dependencies for faster workflows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893fe27bc04832fac16e9057983a80b