### PR TITLE
ci: use npm install with caching

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,4 +1,4 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# This workflow installs dependencies and publishes a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
@@ -16,8 +16,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm test
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - run: npm install
 
   publish-gpr:
     needs: build
@@ -31,7 +32,9 @@ jobs:
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
-      - run: npm ci
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - run: npm install
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- use `npm install` in CI workflows instead of `npm ci`
- cache npm dependencies for faster workflows
- remove `npm test` step because no tests defined

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893fe27bc04832fac16e9057983a80b