### PR TITLE
docs: document GitHub Pages base path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ import { Link, Route, Routes } from \"react-router-dom\";
 - [React Router 공식 문서](https://reactrouter.com/)
 - [Ant Design 공식 문서](https://ant.design/)
 
+## 📝 PR 변경 사항
+
+- GitHub Pages 배포를 위해 `vite.config.js`의 `base` 경로를 `/study_my_id_card/`로 설정했습니다.
+
 ## 🤝 기여 방법
 
 1. 이 저장소를 Fork합니다


### PR DESCRIPTION
## Summary
- document GitHub Pages base path setting in vite.config.js

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bc7a1e10832fa3958280d9933326